### PR TITLE
add missing source line

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem "sinatra"
 gem "omniauth-bookingsync"
 gem "json"


### PR DESCRIPTION
Fixing this error that bundle gave:                                                                                                                                                                                                                               
Your Gemfile has no gem server sources. If you need gems that are not already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'