### PR TITLE
Bump oauth2 ~> 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #master
 
+* Bump oauth2 ~> 1.4
+
 # 0.5.0 - 2017-04-22
 
 * Add support for omniauth-oauth2 1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-bookingsync (0.5.0)
-      oauth2 (~> 1.3.0)
+      oauth2 (~> 1.4)
       omniauth (~> 1.6)
       omniauth-oauth2 (<= 1.4)
 
@@ -15,15 +15,15 @@ GEM
       thor (>= 0.14.0)
     ast (2.3.0)
     diff-lcs (1.3)
-    faraday (0.11.0)
+    faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     hashie (3.5.5)
     jwt (1.5.6)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    oauth2 (1.3.1)
-      faraday (>= 0.8, < 0.12)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -37,7 +37,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
-    rack (2.0.1)
+    rack (2.0.3)
     rainbow (2.2.2)
       rake
     rake (12.0.0)
@@ -75,4 +75,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/omniauth-bookingsync.gemspec
+++ b/omniauth-bookingsync.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "omniauth", "~> 1.6"
   gem.add_dependency "omniauth-oauth2", "<= 1.4"
-  gem.add_dependency "oauth2", "~> 1.3.0"
+  gem.add_dependency "oauth2", "~> 1.4"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Minor changes on Changelog: 
drop ruby 1.8, update faraday deps, remove useless dependencies